### PR TITLE
Faithfulness score

### DIFF
--- a/src/vragas/metrics/__init__.py
+++ b/src/vragas/metrics/__init__.py
@@ -1,10 +1,16 @@
 from .exact import ExactMatch
 from .soft import SoftMatch
 from .fscore import F1Score
+from .faithfulness_score import FaithfulnessScore
+from .collection import MetricsCollection
 
 
 __all__ = [
     'ExactMatch',
     'SoftMatch',
-    'F1Score'
+    'F1Score',
+    # Semantic Metrics
+    'FaithfulnessScore',
+    # Containers
+    'MetricsCollection',
 ]

--- a/src/vragas/metrics/clip.py
+++ b/src/vragas/metrics/clip.py
@@ -1,0 +1,69 @@
+import torch
+import requests
+from PIL import Image
+from statistics import mean
+from transformers import CLIPModel, CLIPProcessor
+from typing import get_args, Dict, Union, Literal
+
+from .base import Id, EvalInput, Metric, MetricValue
+
+
+DType = Literal["float16", "bfloat16", "float32"]
+Device = Literal["cpu", "cuda"]
+
+
+class CLIPScore(Metric):
+
+    name = "clip_score"
+
+    def __init__(
+        self,
+        model: str,
+        device: Union[Device, torch.device] = None,
+        dtype: Union[DType, torch.dtype] = torch.float32,
+    ):
+        super().__init__()
+        if not device:
+            device = "cuda" if torch.cuda.is_available() else "cpu"
+        elif isinstance(device, str) and device not in get_args(Device):
+            raise ValueError(f"Invalid device: {device}")
+        if isinstance(dtype, str) and dtype in get_args(DType):
+            dtype = getattr(torch, dtype)
+        elif isinstance(dtype, str):
+            raise ValueError(f"Unknown dtype: {dtype}")
+
+        self.device = torch.device(device)
+        self.model = CLIPModel.from_pretrained(model).to(device, dtype=dtype)
+        self.model.eval()
+        self.processor = CLIPProcessor.from_pretrained(model)
+
+    def score(self, text: str, image: Image.Image) -> float:
+        inputs = self.processor(
+            text=text, images=image,
+            return_tensors="pt", padding=True
+        ).to(self.device)
+
+        with torch.no_grad():
+            ouputs = self.model(**inputs)
+            text_embeds, image_embeds = ouputs.text_embeds, ouputs.image_embeds
+
+        similarity: torch.Tensor = (text_embeds * image_embeds).sum(dim=-1)
+        return similarity.relu().item()
+
+    def update(self, input: EvalInput) -> None:
+        """
+            Update metric state with input response
+        """
+        image = Image.open(
+            requests.get(input["image_input"], stream=True).raw
+        )
+        score = self.score(input["response"], image)
+        self.state[input["id"]] = score
+
+    def report(self) -> Dict[Id, float]:
+        return self.state.copy()
+
+    def compute(self) -> MetricValue:
+        return {
+            self.name: mean(self.state.values())
+        }

--- a/src/vragas/metrics/faithfulness_score.py
+++ b/src/vragas/metrics/faithfulness_score.py
@@ -1,0 +1,88 @@
+from typing import Union
+from langchain.llms.base import BaseLLM
+from langchain.chat_models.base import BaseChatModel
+from langchain.prompts import ChatPromptTemplate, PromptTemplate
+from langchain_core.messages import AIMessage
+
+from .clip import CLIPScore, EvalInput
+
+
+INSTRUCTION = """
+Given a question and answer, create a statement that summarizes
+the question and answer main proposition. Follow the examples structure:
+
+Examples:
+
+question: What kind of drink is inside the glass?
+answer: It seem to be white wine.
+statement: The glass is filled with white wine.
+---
+question: What activity do the man and the woman appear to be doing?
+answer: They seem to be playing a videogame.
+statement: A man and a woman are playing videogame.
+---
+question: What appears to be the purpose of the microwave being placed on the asphalt?
+answer: The microwave appears to have been thrown away.
+statement: A microwave was thrown away and placed on the asphalt.
+---
+question: Is the train a passenger or freight train?
+answer: It's a freight train.
+statement: The train is a freight train.
+---
+""".strip()
+
+
+TEMPLATE = """
+question: {question}
+answer: {answer}
+statement:
+""".strip()
+
+
+def parse_output_statements(output: Union[str, AIMessage]) -> str:
+    if isinstance(output, AIMessage):
+        output = output.content
+    return output
+
+
+def get_chain_for_model(model):
+    if isinstance(model, BaseLLM):
+        prompt = PromptTemplate.from_template(
+            INSTRUCTION + "\n" + TEMPLATE
+        )
+    elif isinstance(model, BaseChatModel):
+        prompt = ChatPromptTemplate.from_messages([
+            ("system", INSTRUCTION),
+            ("human", TEMPLATE)
+        ])
+    else:
+        raise ValueError(f"invalid model class {type(model)}")
+    
+    return prompt | model | parse_output_statements
+
+
+class FaithfulnessScore(CLIPScore):
+    name = "faithfulness_score"
+
+    def __init__(
+        self,
+        language_model: Union[BaseLLM, BaseChatModel],
+        clip_model: str = "openai/clip-vit-base-patch32",
+        **clip_kwargs
+    ):
+        super().__init__(clip_model, **clip_kwargs)
+        self.responses = dict()
+        self.chain = get_chain_for_model(language_model)
+    
+    def update(self, input: EvalInput) -> None:
+        sentence = self.chain.invoke({
+            "question": input["user_input"],
+            "answer": input["response"]
+        })
+        self.responses[input["id"]] = sentence
+        rewritten_input = {
+            "id": input["id"],
+            "image_input": input["image_input"],
+            "response": sentence
+        }
+        return super().update(rewritten_input)

--- a/tests/test_faithfulness.py
+++ b/tests/test_faithfulness.py
@@ -1,0 +1,75 @@
+from langchain_core.language_models import FakeListLLM, FakeListChatModel
+
+from src.vragas.metrics import FaithfulnessScore
+
+
+def test_faithfulness_score_with_llm():
+    data = [
+        {
+            "id": 1,
+            "image_input": "http://images.cocodataset.org/train2017/000000517382.jpg",
+            "user_input": "What activity do the man and the woman appear to be doing?",
+            "response": "They are playing videogame.",
+        },
+        {
+            "id": 2,
+            "image_input": "http://images.cocodataset.org/train2017/000000370278.jpg",
+            "user_input": "What type of meal is laid out on the table?",
+            "response": "A hotel breakfast",
+        }
+    ]
+
+    faithfulness = FaithfulnessScore(
+        language_model=FakeListLLM(
+            responses=[
+                "A man and a women are playing videogame", 
+                "A hotel breakfast is laid out on the table"
+            ]
+        ),
+        dtype="bfloat16"
+    )
+
+    faithfulness.update(data[0])
+    faithfulness.update(data[1])
+
+    report = faithfulness.report()
+    assert all(v >= 0 for v in report.values())
+    score = faithfulness.compute()
+    assert "faithfulness_score" in score
+    assert score["faithfulness_score"] >= 0.0
+
+
+def test_faithfulness_score_with_chat_model():
+    data = [
+        {
+            "id": 1,
+            "image_input": "http://images.cocodataset.org/train2017/000000517382.jpg",
+            "user_input": "What activity do the man and the woman appear to be doing?",
+            "response": "They are playing videogame.",
+        },
+        {
+            "id": 2,
+            "image_input": "http://images.cocodataset.org/train2017/000000370278.jpg",
+            "user_input": "What type of meal is laid out on the table?",
+            "response": "A hotel breakfast",
+        }
+    ]
+
+    faithfulness = FaithfulnessScore(
+        language_model=FakeListChatModel(
+            responses=[
+                "A man and a women are playing videogame", 
+                "A hotel breakfast is laid out on the table"
+            ]
+        ),
+        dtype="bfloat16"
+    )
+
+    faithfulness.update(data[0])
+    faithfulness.update(data[1])
+
+    report = faithfulness.report()
+    assert all(v >= 0 for v in report.values())
+    score = faithfulness.compute()
+    assert "faithfulness_score" in score
+    assert score["faithfulness_score"] >= 0.0


### PR DESCRIPTION
This PR:

1. Add CLIPScore to codebase. CLIPScore is meant for applications that require a quantitative measure between visual content and accompanying natural language descriptions/captions by leveraging modern pretrained multimodal models like CLIP to understand how well they match up in terms of the represented concepts or objects within them.
2. Add Faithfulness Score. The FaithfulnessScore subclass of CLIPScore, built for assessing faithfulness in textual responses within QA contexts, introduces an additional language model as its primary component to process and generate question-answer pairs from user inputs before updating the CLIP score with image data. 
3. Add Faithfulness Score tests. Those tests are meant to run in local environment only.